### PR TITLE
Update darwin-arm64 platform, version 4.4.1

### DIFF
--- a/platforms/darwin-arm64/package.json
+++ b/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ffprobe-darwin-arm64",
-	"version": "4.4.0",
+	"version": "4.4.1",
 	"description": "Mac OS X FFmpeg binary used by ffprobe-installer",
 	"homepage": "https://formulae.brew.sh/formula/ffmpeg",
 	"scripts": {
@@ -23,5 +23,5 @@
 	],
 	"author": "Honeyside",
 	"license": "LGPL-2.1",
-	"ffprobe": "4.4"
+	"ffprobe": "4.4.1"
 }


### PR DESCRIPTION
I recompiled the ffprobe from FFmpeg with Apple Silicon. The reason I recompile the executable, is that the current [executable](https://github.com/Honeyside/node-ffprobe-installer/blob/82a332fe15aaf1118bf052e956930585b591a6ce/platforms/darwin-arm64/ffprobe) is not a standalone executable.

1. It's only 279KB size
2. When it was run, it prompts for loading another library
```
dyld[39699]: Library not loaded: /opt/homebrew/Cellar/ffmpeg/4.4_1/lib/libavdevice.58.dylib
  Referenced from: /***/node-ffprobe-installer/platforms/darwin-arm64/ffprobe
  Reason: tried: '/opt/homebrew/Cellar/ffmpeg/4.4_1/lib/libavdevice.58.dylib' (no such file), '/usr/local/lib/libavdevice.58.dylib' (no such file), '/usr/lib/libavdevice.58.dylib' (no such file)
zsh: abort      ./ffprobe
```